### PR TITLE
PareDownPolandScraper

### DIFF
--- a/integ_test/test_scrapers.py
+++ b/integ_test/test_scrapers.py
@@ -61,16 +61,16 @@ def check_common(put_item):
     return func
 
 
-def test_poland_pl(put_item, check_common):
-    poland_scraper = PolandScraper()
-    poland_scraper.scrape_poland_pl()
-    check_common("poland-pl")
+# def test_poland_pl(put_item, check_common):
+#     poland_scraper = PolandScraper()
+#     poland_scraper.scrape_poland_pl()
+#     check_common("poland-pl")
 
 
-def test_poland_en(put_item, check_common):
-    poland_scraper = PolandScraper()
-    poland_scraper.scrape_poland_en()
-    check_common("poland-en")
+# def test_poland_en(put_item, check_common):
+#     poland_scraper = PolandScraper()
+#     poland_scraper.scrape_poland_en()
+#     check_common("poland-en")
 
 
 def test_poland_ua(put_item, check_common):

--- a/src/scrapers/poland.py
+++ b/src/scrapers/poland.py
@@ -10,12 +10,13 @@ POLAND_PL_RECEPTION_URL = "https://www.gov.pl/web/udsc/punkty-recepcyjne2"
 # POLAND_EN_URL = "https://www.gov.pl/web/udsc/ukraina-en"
 # POLAND_PL_URL = "https://www.gov.pl/web/udsc/ukraina2"
 
+
 class PolandScraper(BaseScraper):
     def scrape(self, event=""):
         self.scrape_poland_ua(event)
         # self.scrape_poland_pl(event)
         # self.scrape_poland_en(event)
-        
+
     def scrape_poland_ua(self, event=""):
         print("Scraping Poand (UA)")
 

--- a/src/scrapers/poland.py
+++ b/src/scrapers/poland.py
@@ -3,37 +3,36 @@ from utils.reception import Reception
 from utils.utils import get_website_content, gmaps_url_to_lat_lon, normalize
 from utils.dynamo import write_to_dynamo
 
-POLAND_EN_URL = "https://www.gov.pl/web/udsc/ukraina-en"
-POLAND_PL_URL = "https://www.gov.pl/web/udsc/ukraina2"
 POLAND_UA_URL = "https://www.gov.pl/web/udsc/ukraina---ua"
-
-
 POLAND_PL_RECEPTION_URL = "https://www.gov.pl/web/udsc/punkty-recepcyjne2"
 
+# Keeping these ULRs around as a backup incase they are ever needed
+# POLAND_EN_URL = "https://www.gov.pl/web/udsc/ukraina-en"
+# POLAND_PL_URL = "https://www.gov.pl/web/udsc/ukraina2"
 
 class PolandScraper(BaseScraper):
     def scrape(self, event=""):
-        self.scrape_poland_pl(event)
-        self.scrape_poland_en(event)
         self.scrape_poland_ua(event)
-
-    def scrape_poland_pl(self, event=""):
-        print("Scraping Poland (PL)")
-
-        """calls scrape_poland with the appropriate arguments for the pl website"""
-        self.scrape_poland(POLAND_PL_URL, "pl", event)
-
-    def scrape_poland_en(self, event=""):
-        print("Scraping Poland (EN)")
-
-        """calls scrape_poland with the appropriate arguments for the en website"""
-        self.scrape_poland(POLAND_EN_URL, "en", event)
-
+        # self.scrape_poland_pl(event)
+        # self.scrape_poland_en(event)
+        
     def scrape_poland_ua(self, event=""):
         print("Scraping Poand (UA)")
 
         """calls scrape_poland with the appropriate arguments for the ua website"""
         self.scrape_poland(POLAND_UA_URL, "ua", event)
+
+    # def scrape_poland_pl(self, event=""):
+    #     print("Scraping Poland (PL)")
+
+    #     """calls scrape_poland with the appropriate arguments for the pl website"""
+    #     self.scrape_poland(POLAND_PL_URL, "pl", event)
+
+    # def scrape_poland_en(self, event=""):
+    #     print("Scraping Poland (EN)")
+
+    #     """calls scrape_poland with the appropriate arguments for the en website"""
+    #     self.scrape_poland(POLAND_EN_URL, "en", event)
 
     def get_core(self, content, locale):
         """Gets the content from a bullet points list of general information for Ukrainian citizens."""


### PR DESCRIPTION
Pared down the poland scraper to only scrape in Ukrainian. Keeping track of multiple languages per country is proving to be difficult. Will instead make 1 scraper, per country, and translate from there.

Only commented code out so, if we need to bring back additional scrapers, we can do so quickly